### PR TITLE
Automatic state switching, toggle individual OBS sources, no more hotkey shenanigans

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,16 @@
 plugins {
     id 'java'
+    id 'idea'
 }
 
 group = project.maven_group
 version = project.plugin_version
 archivesBaseName = project.archives_base_name
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 repositories {
     mavenCentral()
@@ -24,9 +27,14 @@ configurations {
     implementation.extendsFrom(provided)
 }
 
+// Ensures latest Jingle commit
+configurations.configureEach {
+    resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
+}
+
 dependencies {
     // https://jitpack.io/#DuncanRuns/Jingle/
-    implementation 'com.github.DuncanRuns:Jingle:v1.1.1'
+    implementation 'com.github.DuncanRuns:Jingle:main-SNAPSHOT'
 }
 
 processResources {
@@ -38,10 +46,16 @@ processResources {
 }
 
 jar {
+    duplicatesStrategy DuplicatesStrategy.EXCLUDE
+
     manifest {
         attributes(
             'Implementation-Version': project.version
         )
     }
-    from configurations.provided.asFileTree.files.collect { zipTree(it) }
+
+    from { configurations.provided.asFileTree.files.collect { zipTree(it) } } {
+        include '**/*.class'
+        exclude '**/module-info.*'
+    }
 }

--- a/src/main/java/me/disheiX/switcher/SceneSwitcher.java
+++ b/src/main/java/me/disheiX/switcher/SceneSwitcher.java
@@ -12,9 +12,7 @@ import xyz.duncanruns.jingle.plugin.PluginManager;
 import xyz.duncanruns.jingle.util.FileUtil;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.nio.file.Path;
-import java.nio.file.FileAlreadyExistsException;
-import java.nio.file.Files;
+import java.nio.file.*;
 import java.io.InputStream;
 import java.util.Objects;
 import javax.swing.Timer;
@@ -94,9 +92,7 @@ public class SceneSwitcher {
         try {
             String scriptPath = "jingle-obs-switcher.lua";
             InputStream from = SceneSwitcher.class.getResourceAsStream("/" + scriptPath);
-            Files.copy(from, LUA_SCRIPT_PATH);
-        } catch (FileAlreadyExistsException e) {
-            Jingle.log(Level.INFO, "(SceneSwitcher) jingle-obs-switcher.lua already exists");
+            Files.copy(from, LUA_SCRIPT_PATH, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
             Jingle.logError("(SceneSwitcher) Failed to write the obs link script", e);
         }

--- a/src/main/java/me/disheiX/switcher/SceneSwitcher.java
+++ b/src/main/java/me/disheiX/switcher/SceneSwitcher.java
@@ -1,5 +1,7 @@
 package me.disheiX.switcher;
 
+import me.disheiX.switcher.state.ObsState;
+import me.disheiX.switcher.state.ObsStateManager;
 import me.disheiX.switcher.util.ResizingStateUtil;
 import com.google.common.io.Resources;
 import me.disheiX.switcher.gui.SceneSwitcherGUI;
@@ -7,53 +9,21 @@ import org.apache.logging.log4j.Level;
 import xyz.duncanruns.jingle.Jingle;
 import xyz.duncanruns.jingle.JingleAppLaunch;
 import xyz.duncanruns.jingle.gui.JingleGUI;
-import xyz.duncanruns.jingle.plugin.PluginHotkeys;
+import xyz.duncanruns.jingle.instance.InstanceState;
+import xyz.duncanruns.jingle.plugin.PluginEvents;
 import xyz.duncanruns.jingle.plugin.PluginManager;
-import xyz.duncanruns.jingle.util.FileUtil;
+import xyz.duncanruns.jingle.script.CustomizableManager;
+import xyz.duncanruns.jingle.util.WindowStateUtil;
+
+import java.awt.*;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.*;
 import java.io.InputStream;
-import java.util.Objects;
-import javax.swing.Timer;
 
 public class SceneSwitcher {
-    private static final Path OUT = Jingle.FOLDER.resolve("obs-switcher-state");
     private static final Path LUA_SCRIPT_PATH = Jingle.FOLDER.resolve("jingle-obs-switcher.lua");
-    private static long lastUpdate = 0L;
-    private static String last = "";
-    private static SceneState currentScene = SceneState.NONE; // Change default state
-    private static Timer resizeCheckTimer;  // Add timer field
-
-    private static void setCurrentScene(SceneState newScene) {
-        currentScene = newScene;
-        tick();
-    }
-
-    private enum SceneState {
-        PLANNAR_ABUSE,
-        MAG,
-        THIN,
-        CUSTOM,
-        PLAYING,
-        NONE;
-
-        private String customName;
-
-        public void setCustomName(String name) {
-            this.customName = name;
-        }
-
-        public String formatOutput() {
-            StringBuilder output = new StringBuilder();
-            output.append(PLAYING.customName != null ? PLAYING.customName : "N").append("|");
-            output.append(currentScene == PLANNAR_ABUSE ? PLANNAR_ABUSE.customName : "N").append("|");
-            output.append(currentScene == MAG ? MAG.customName : "N").append("|");
-            output.append(currentScene == THIN ? THIN.customName : "N").append("|");
-            output.append(currentScene == CUSTOM ? CUSTOM.customName : "N");
-            return output.toString();
-        }
-    }
+    private static ObsState lastState;
 
     public static void main(String[] args) throws IOException {
         JingleAppLaunch.launchWithDevPlugin(args, PluginManager.JinglePluginData.fromString(
@@ -64,106 +34,58 @@ public class SceneSwitcher {
     public static void initialize() {
         String version = SceneSwitcher.class.getPackage().getImplementationVersion();
         Jingle.log(Level.INFO, "SceneSwitcher v" + (version != null ? version : "DEV") + " plugin initialized");
-        JingleGUI.addPluginTab("OBS Scene Switcher", new SceneSwitcherGUI());
-        PluginHotkeys.addHotkeyAction("Scene Switcher - Eye Measuring", () -> switchToMag(SceneSwitcherOptions.getInstance().mag_scene.name));
-        PluginHotkeys.addHotkeyAction("Scene Switcher - Plannar Abuse", () -> switchToPlannarAbuse(SceneSwitcherOptions.getInstance().plannar_abuse_scene.name));
-        PluginHotkeys.addHotkeyAction("Scene Switcher - Thin BT", () -> switchToThin(SceneSwitcherOptions.getInstance().thin_scene.name));
-        generateResources();
-        startResizeCheckTimer();
-    }
 
-    // Fallback in case the resize check fails
-    private static void startResizeCheckTimer() {
-        if (resizeCheckTimer != null) {
-            resizeCheckTimer.stop();
-        }
-        resizeCheckTimer = new Timer(1000, e -> {
-            if (SceneSwitcherOptions.getInstance().enabled && 
-                !ResizingStateUtil.isCurrentlyResized() 
-                && (currentScene != SceneState.PLAYING)
-                && (currentScene != SceneState.CUSTOM)) {
-                    setCurrentScene(SceneState.PLAYING);
+        CustomizableManager.load();
+
+        SceneSwitcherOptions.load();
+        lastState = SceneSwitcherOptions.getDefaultState();
+
+        JingleGUI.addPluginTab("OBS Scene Switcher", new SceneSwitcherGUI());
+        generateResources();
+
+        PluginEvents.END_TICK.register(() -> {
+            try {
+                checkResize();
+            } catch (Exception e) {
+                Jingle.logError("(SceneSwitcher) Error while checking for resize", e);
             }
         });
-        resizeCheckTimer.start();
+    }
+
+    public static void checkResize() {
+        if (!Jingle.getMainInstance().isPresent() ||
+                !SceneSwitcherOptions.getInstance().enabled ||
+                !Jingle.isInstanceActive() ||
+                !Jingle.getMainInstance().get().stateTracker.isCurrentState(InstanceState.INWORLD)
+        ) {
+            return;
+        }
+
+        if (lastState.equals(SceneSwitcherOptions.getDefaultState()) && !ResizingStateUtil.isCurrentlyResized()) {
+            return;
+        }
+
+        Rectangle currentRectangle = WindowStateUtil.getHwndRectangle(Jingle.getMainInstance().get().hwnd);
+        ObsState currentState = SceneSwitcherOptions.getStateMatchingRectangle(currentRectangle);
+
+        if (lastState.getName().equals(currentState.getName())) {
+            return;
+        }
+
+        lastState = ObsStateManager.updateState(lastState, currentState);
     }
 
     private static void generateResources() {
-        try {
-            String scriptPath = "jingle-obs-switcher.lua";
-            InputStream from = SceneSwitcher.class.getResourceAsStream("/" + scriptPath);
+        String scriptPath = "jingle-obs-switcher.lua";
+        try (InputStream from = SceneSwitcher.class.getResourceAsStream("/" + scriptPath)) {
+            assert from != null;
             Files.copy(from, LUA_SCRIPT_PATH, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
-            Jingle.logError("(SceneSwitcher) Failed to write the obs link script", e);
+            Jingle.logError("(SceneSwitcher) Failed to write the state link script", e);
         }
     }
 
     public static Path getLuaScriptPath() {
         return LUA_SCRIPT_PATH;
-    }
-
-    public static void tick() {
-        long currentTime = System.currentTimeMillis();
-        if (Math.abs(currentTime - lastUpdate) > 10L) {
-            lastUpdate = currentTime;
-            String output = currentScene.formatOutput();
-            if (Objects.equals(output, last))
-                return; 
-            last = output;
-            try {
-                FileUtil.writeString(OUT, output);
-            } catch (IOException e) {
-                Jingle.logError("(SceneSwitcher) Failed to write obs-link-state:", e);
-            } 
-        } 
-    }
-
-    public static void switchToPlannarAbuse(String sceneName) {
-        if (!SceneSwitcherOptions.getInstance().enabled) return;
-        boolean isResized = ResizingStateUtil.isCurrentlyResized();
-        if (isResized) {
-            SceneState.PLANNAR_ABUSE.setCustomName(sceneName);
-            setCurrentScene(SceneState.PLANNAR_ABUSE);
-        } else {
-            setCurrentScene(SceneState.PLAYING);
-        }
-    }
-
-    public static void switchToMag(String sceneName) {
-        if (!SceneSwitcherOptions.getInstance().enabled) return;
-        boolean isResized = ResizingStateUtil.isCurrentlyResized();
-        if (isResized) {
-            SceneState.MAG.setCustomName(sceneName);
-            setCurrentScene(SceneState.MAG);
-        } else {
-            setCurrentScene(SceneState.PLAYING);
-        }
-    }
-
-    public static void switchToThin(String sceneName) {
-        if (!SceneSwitcherOptions.getInstance().enabled) return;
-        boolean isResized = ResizingStateUtil.isCurrentlyResized();
-        if (isResized) {
-            SceneState.THIN.setCustomName(sceneName);
-            setCurrentScene(SceneState.THIN);
-        } else {
-            setCurrentScene(SceneState.PLAYING);
-        }
-    }
-
-    public static void switchToCustom(String scene) {
-        if (!SceneSwitcherOptions.getInstance().enabled) return;
-        if (currentScene != SceneState.CUSTOM) {
-            SceneState.CUSTOM.setCustomName(scene);
-            setCurrentScene(SceneState.CUSTOM);
-        } else {
-            setCurrentScene(SceneState.PLAYING);
-        }
-    }
-
-    public static void updatePlayingScene(String sceneName) {
-        if (!SceneSwitcherOptions.getInstance().enabled) return;
-        SceneState.PLAYING.setCustomName(sceneName);
-        tick();
     }
 }

--- a/src/main/java/me/disheiX/switcher/SceneSwitcherOptions.java
+++ b/src/main/java/me/disheiX/switcher/SceneSwitcherOptions.java
@@ -1,82 +1,121 @@
 package me.disheiX.switcher;
 
 import com.google.gson.*;
+import me.disheiX.switcher.state.ObsState;
 import xyz.duncanruns.jingle.Jingle;
+import xyz.duncanruns.jingle.script.CustomizableManager;
+import xyz.duncanruns.jingle.util.FileUtil;
 
-import java.io.FileWriter;
+import java.awt.*;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class SceneSwitcherOptions {
-    public static class SceneData {
-        public String name = "";
-
-        public SceneData() {}
-
-        public SceneData(String name) {
-            this.name = name;
-        }
-    }
-
-    public SceneData mag_scene = new SceneData();
-    public SceneData plannar_abuse_scene = new SceneData();
-    public SceneData thin_scene = new SceneData();
-    public SceneData playing_scene = new SceneData();
-    public boolean enabled = true;
-    public Map<String, SceneData> custom_scenes = new HashMap<>();
-
-    public SceneSwitcherOptions() {
-        // default values for new instances
-        mag_scene.name = "Jingle Mag";
-        playing_scene.name = "Playing";
-        plannar_abuse_scene.name = "";
-        thin_scene.name = "";
-        enabled = true;
-    }
-
-    private static final Gson GSON = new GsonBuilder()
-            .registerTypeAdapter(SceneData.class, new JsonDeserializer<SceneData>() {
-                @Override
-                public SceneData deserialize(JsonElement json, java.lang.reflect.Type typeOfT, JsonDeserializationContext context) {
-                    if (json.isJsonPrimitive()) {
-                        // Handle old format where scene was just a string
-                        return new SceneData(json.getAsString());
-                    } else {
-                        // Handle new format
-                        JsonObject obj = json.getAsJsonObject();
-                        return new SceneData(obj.has("name") ? obj.get("name").getAsString() : "");
-                    }
-                }
-            })
-            .setPrettyPrinting()
-            .create();
-
     private static final Path CONFIG_PATH = Jingle.FOLDER.resolve("scene-switcher-config.json");
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().serializeNulls().create();
     private static SceneSwitcherOptions instance;
 
-    public static void save() throws IOException {
-        try (FileWriter writer = new FileWriter(CONFIG_PATH.toFile())) {
-            writer.write(GSON.toJson(getInstance()));
+    public boolean enabled;
+    public List<ObsState> obsStates;
+
+    public static void load() {
+        if (!Files.exists(CONFIG_PATH)) {
+            loadDefaultSettings();
+        } else {
+            String s;
+            try {
+                s = FileUtil.readString(CONFIG_PATH);
+                instance = GSON.fromJson(s, SceneSwitcherOptions.class);
+            } catch (IOException | JsonSyntaxException e) {
+                Jingle.logError("(SceneSwitcher) Error while reading settings, resetting back to default:", e);
+                loadDefaultSettings();
+            }
         }
+        validate();
+        save();
+    }
+
+    public static void validate() {
+        if (instance.obsStates == null) {
+            instance.obsStates = defaultObsStates();
+            return;
+        }
+
+        List<ObsState> remove = new ArrayList<>();
+        for (ObsState obsState: instance.obsStates) {
+            try {
+                if (obsState.getName().isEmpty() || obsState.getActiveScene().isEmpty() || obsState.getToggledSources().isEmpty()) {
+                    throw new NullPointerException();
+                }
+                obsState.getDimensions();
+            } catch (NullPointerException e) {
+                remove.add(obsState);
+            }
+        }
+        instance.obsStates.removeAll(remove);
+        if (instance.obsStates.isEmpty()) {
+            instance.obsStates = defaultObsStates();
+        }
+        getDefaultState();
+    }
+
+    public static void save() {
+        try {
+            FileUtil.writeString(CONFIG_PATH, GSON.toJson(instance));
+        } catch (IOException e) {
+            Jingle.logError("(SceneSwitcher) Failed to save SceneSwitcher settings:", e);
+        }
+    }
+
+    private static void loadDefaultSettings() {
+        instance = new SceneSwitcherOptions();
+        instance.enabled = true;
+        instance.obsStates = defaultObsStates();
+    }
+
+    private static List<ObsState> defaultObsStates() {
+        List<ObsState> obsStates = new ArrayList<>();
+        obsStates.add(new ObsState("Playing", "0x0", "Playing", ""));
+        obsStates.add(new ObsState("eye_measuring", CustomizableManager.get("Resizing", "eye_measuring"), "Playing", ""));
+        obsStates.add(new ObsState("planar_abuse", CustomizableManager.get("Resizing", "planar_abuse"), "Playing", ""));
+        obsStates.add(new ObsState("thin_bt", CustomizableManager.get("Resizing", "thin_bt"), "Playing", ""));
+        return obsStates;
+    }
+
+    public static ObsState getDefaultState() {
+        return instance.obsStates.stream().filter(obsState -> obsState.getName().equals("Playing")).findFirst().orElseGet(() -> {
+            instance.obsStates.add(0, new ObsState("Playing", "0x0", "Playing", ""));
+            return instance.obsStates.get(0);
+        });
+    }
+
+    public static List<String> getAllSources() {
+        return instance.obsStates.stream()
+                .map(ObsState::getToggledSources)
+                .flatMap(Collection::stream)
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
+    public static ObsState getStateMatchingRectangle(Rectangle rectangle) {
+        return instance.obsStates.stream()
+                .filter(obsState -> obsState.matchesRectangle(rectangle))
+                .findFirst().orElse(getDefaultState());
+    }
+
+    public static boolean matchingExistingName(String nameString) {
+        return instance.obsStates.stream().anyMatch(obsState -> obsState.getName().equals(nameString));
+    }
+
+    public static boolean matchingExistingDimensions(String sizeString) {
+        return instance.obsStates.stream().anyMatch(obsState -> obsState.getDimensions().equals(sizeString));
     }
 
     public static SceneSwitcherOptions getInstance() {
-        if (instance == null) {
-            try {
-                if (Files.exists(CONFIG_PATH)) {
-                    String json = new String(Files.readAllBytes(CONFIG_PATH));
-                    instance = GSON.fromJson(json, SceneSwitcherOptions.class);
-                } else {
-                    instance = new SceneSwitcherOptions();
-                }
-            } catch (IOException e) {
-                instance = new SceneSwitcherOptions();
-            }
-        }
         return instance;
     }
 }
-

--- a/src/main/java/me/disheiX/switcher/gui/ObsStateElement.java
+++ b/src/main/java/me/disheiX/switcher/gui/ObsStateElement.java
@@ -1,0 +1,162 @@
+package me.disheiX.switcher.gui;
+
+import me.disheiX.switcher.SceneSwitcherOptions;
+import me.disheiX.switcher.state.ObsState;
+import xyz.duncanruns.jingle.Jingle;
+
+import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import java.awt.*;
+import java.util.function.Predicate;
+
+public class ObsStateElement {
+    public JLabel obsStateIdLabel;
+    public JTextField dimensionsField;
+    public JTextField sceneNameField;
+    public JTextField toggledSourcesField;
+    public JButton removeButton;
+
+    public SceneSwitcherGUI panel;
+    public ObsState obsState;
+
+    ObsStateElement(SceneSwitcherGUI panel, ObsState obsState) {
+        this.obsStateIdLabel = new JLabel(obsState.getName() + ":");
+        this.dimensionsField = new JTextField(obsState.getDimensions());
+        this.sceneNameField = new JTextField(obsState.getActiveScene());
+        this.toggledSourcesField = new JTextField(String.join(", ", obsState.getToggledSources()));
+        this.removeButton = new JButton("x");
+        this.removeButton.setMargin(new Insets(0, 1, 0, 1));
+        this.removeButton.setForeground(Color.RED);
+
+        this.panel = panel;
+        this.obsState = obsState;
+    }
+
+    public void build() {
+        this.addNewChangeListener(this.dimensionsField, ObsState::isValidDimensionsString, "setDimensions");
+        this.addNewChangeListener(this.sceneNameField, s -> !s.trim().isEmpty(), "setActiveScene");
+        this.addNewChangeListener(this.toggledSourcesField, ObsState::isValidSourcesListString, "setToggledSources");
+
+        this.addRemoveActionListener();
+
+        this.panel.getScenesPanel().add(this.obsStateIdLabel, SceneSwitcherGUI.gbc);
+        this.panel.getScenesPanel().add(this.sceneNameField, SceneSwitcherGUI.gbc);
+        this.panel.getScenesPanel().add(this.toggledSourcesField, SceneSwitcherGUI.gbc);
+        this.panel.getScenesPanel().add(this.dimensionsField, SceneSwitcherGUI.gbc);
+        this.panel.getScenesPanel().add(this.removeButton, SceneSwitcherGUI.gbc);
+        SceneSwitcherGUI.gbc.gridy++;
+    }
+
+    public void setEnabled(boolean enable) {
+        this.dimensionsField.setEnabled(enable);
+        this.sceneNameField.setEnabled(enable);
+        this.toggledSourcesField.setEnabled(enable);
+        this.removeButton.setEnabled(enable);
+    }
+
+    protected void addNewChangeListener(JTextField textField, Predicate<String> validator, String stateMethod) {
+        textField.getDocument().addDocumentListener((ChangeListener) e -> {
+            textField.setForeground(validator.test(textField.getText()) ? null : Color.RED);
+            if (validator.test(textField.getText())) {
+                try {
+                    this.obsState.getClass().getDeclaredMethod(stateMethod, String.class).invoke(this.obsState, textField.getText());
+                    SceneSwitcherOptions.save();
+                } catch (Throwable ex) {
+                    Jingle.logError("(SceneSwitcher) Failed to invoke provided method:", ex);
+                }
+            }
+        });
+    }
+
+    protected void addRemoveActionListener() {
+        this.removeButton.addActionListener(e -> {
+            int choice = JOptionPane.showConfirmDialog(null,
+                    "Are you sure you want to remove '" + this.obsState.getName() + "'?",
+                    "Remove " + this.obsState.getName() + "?", JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
+            if (choice == JOptionPane.YES_OPTION) {
+                SceneSwitcherOptions.getInstance().obsStates.remove(obsState);
+                SceneSwitcherOptions.save();
+                this.panel.updateScenesPanel();
+            }
+        });
+    }
+
+    protected static class Labels extends ObsStateElement {
+        private static final JLabel NAME_LABEL = new JLabel("State Name:");
+        private static final JButton ACTIVE_SCENE_BUTTON = new JButton("Active Scene:");
+        private static final JButton TOGGLED_SOURCES_BUTTON = new JButton("Toggled Sources:");
+        private static final JButton DIMENSIONS_BUTTON = new JButton("Game Size:");
+
+        protected Labels(SceneSwitcherGUI panel) {
+            super(panel, new ObsState("label", "0x0", "", ""));
+        }
+
+        @Override
+        public void build() {
+            ACTIVE_SCENE_BUTTON.setBackground(Color.DARK_GRAY);
+            TOGGLED_SOURCES_BUTTON.setBackground(Color.DARK_GRAY);
+            DIMENSIONS_BUTTON.setBackground(Color.DARK_GRAY);
+
+            ACTIVE_SCENE_BUTTON.addActionListener(e -> JOptionPane.showMessageDialog(null, ACTIVE_SCENE_BUTTON.getText() + "\n" +
+                    "This is the OBS scene that will be active while this state is active.\n" +
+                    "The format is the name of the scene as it is written in OBS.\n" +
+                    "eg. The Jingle default: \"Playing\"",
+                    ACTIVE_SCENE_BUTTON.getText() + " Info", JOptionPane.INFORMATION_MESSAGE));
+            TOGGLED_SOURCES_BUTTON.addActionListener(e -> JOptionPane.showMessageDialog(null, TOGGLED_SOURCES_BUTTON.getText() + "\n" +
+                    "This is a list of OBS scene items that will be toggled to 'enabled' while the state is active, and 'disabled' when the state is deactivated.\n" +
+                    "The format is a comma separated list including, first the name of the scene that the desired source is located, then a colon (':'), then the name of the source as it is written in OBS.\n" +
+                    "eg. The 'calculator' source in the 'Overlays' scene and the 'Mag' source in the 'Projectors' scene: \"Overlays:calculator, Projectors:Mag\"",
+                    TOGGLED_SOURCES_BUTTON.getText() + " Info", JOptionPane.INFORMATION_MESSAGE));
+            DIMENSIONS_BUTTON.addActionListener(e -> JOptionPane.showMessageDialog(null, DIMENSIONS_BUTTON.getText() + "\n" +
+                    "This is the window dimensions that, if your active Minecraft game window matches, will be cause this state to be activated.\n" +
+                    "If you use an ID that the default Resizing script uses, as a new state name, this field will be automatically filled with the existing associated dimensions.\n" +
+                    "The format is the same as the included default Resizing script, first the width, then an 'x', then the height.\n" +
+                    "eg. The default Eye Zoom dimensions: \"384x16384\"",
+                    DIMENSIONS_BUTTON.getText() + " Info", JOptionPane.INFORMATION_MESSAGE));
+
+
+            SceneSwitcherGUI.gbc.fill = GridBagConstraints.NONE;
+            this.panel.getScenesPanel().add(NAME_LABEL, SceneSwitcherGUI.gbc);
+            this.panel.getScenesPanel().add(ACTIVE_SCENE_BUTTON, SceneSwitcherGUI.gbc);
+            this.panel.getScenesPanel().add(TOGGLED_SOURCES_BUTTON, SceneSwitcherGUI.gbc);
+            this.panel.getScenesPanel().add(DIMENSIONS_BUTTON, SceneSwitcherGUI.gbc);
+            SceneSwitcherGUI.gbc.fill = GridBagConstraints.HORIZONTAL;
+            SceneSwitcherGUI.gbc.gridy++;
+        }
+    }
+
+    protected static class DefaultState extends ObsStateElement {
+        protected DefaultState(SceneSwitcherGUI panel, ObsState obsState) {
+            super(panel, obsState);
+        }
+
+        @Override
+        public void build() {
+            this.addNewChangeListener(this.sceneNameField, s -> !s.trim().isEmpty(), "setActiveScene");
+            this.addNewChangeListener(this.toggledSourcesField, ObsState::isValidSourcesListString, "setToggledSources");
+
+            this.panel.getScenesPanel().add(this.obsStateIdLabel, SceneSwitcherGUI.gbc);
+            this.panel.getScenesPanel().add(this.sceneNameField, SceneSwitcherGUI.gbc);
+            this.panel.getScenesPanel().add(this.toggledSourcesField, SceneSwitcherGUI.gbc);
+            SceneSwitcherGUI.gbc.gridy++;
+        }
+    }
+
+    private interface ChangeListener extends DocumentListener {
+        void update(DocumentEvent e);
+
+        @Override
+        default void insertUpdate(DocumentEvent e) {
+            update(e);
+        }
+        @Override
+        default void removeUpdate(DocumentEvent e) {
+            update(e);
+        }
+        @Override
+        default void changedUpdate(DocumentEvent e) {
+            update(e);
+        }
+    }
+}

--- a/src/main/java/me/disheiX/switcher/gui/SceneSwitcherGUI.java
+++ b/src/main/java/me/disheiX/switcher/gui/SceneSwitcherGUI.java
@@ -2,292 +2,169 @@ package me.disheiX.switcher.gui;
 
 import javax.swing.*;
 
+import com.intellij.uiDesigner.core.GridConstraints;
+import com.intellij.uiDesigner.core.GridLayoutManager;
+import me.disheiX.switcher.state.ObsState;
 import org.apache.logging.log4j.Level;
 
 import me.disheiX.switcher.SceneSwitcherOptions;
 import me.disheiX.switcher.SceneSwitcher;
 import xyz.duncanruns.jingle.Jingle;
-import xyz.duncanruns.jingle.hotkey.Hotkey;
-import xyz.duncanruns.jingle.plugin.PluginHotkeys;
 import java.awt.*;
-import java.awt.event.KeyAdapter;
-import java.awt.event.KeyEvent;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import me.disheiX.switcher.util.HotkeyUtil;
-import java.awt.Toolkit;
-import java.awt.datatransfer.StringSelection;
+import xyz.duncanruns.jingle.script.CustomizableManager;
+import xyz.duncanruns.jingle.util.ExceptionUtil;
+import xyz.duncanruns.jingle.util.KeyboardUtil;
+
+import java.util.function.Function;
 
 public class SceneSwitcherGUI extends JPanel {
-    private static SceneSwitcherGUI instance = null;
-    private JCheckBox enabledCheckBox;
-    private JTextField magField, plannarAbuseField, thinField, playingField;
-    private JButton keyButton, addSceneButton;
-    private JPanel scenesPanel;
-    private Map<String, JTextField> customSceneFields = new HashMap<>();
-    private boolean closed = false;
-    private CustomSceneCounter customCounter = new CustomSceneCounter(0);
+    public static final GridBagConstraints gbc = new GridBagConstraints();
+    public static final GridConstraints gc = new GridConstraints();
+
+    private final JPanel mainPanel;
+    private final JPanel enablePanel;
+    private final JPanel scenesPanel;
+    private final JPanel copyPathPanel;
 
     public SceneSwitcherGUI() {
-        SceneSwitcherOptions options = SceneSwitcherOptions.getInstance();
-        setUpWindow();
-        initializeFields(options);
-        addListeners(options);
-        setInitialStates(options);
-        this.revalidate();
-        this.setMinimumSize(new Dimension(300, 200));
+        this.mainPanel = new JPanel(new GridLayoutManager(3, 1));
+        this.enablePanel = new JPanel(new GridBagLayout());
+        this.scenesPanel = new JPanel(new GridBagLayout());
+        this.copyPathPanel = new JPanel(new GridBagLayout());
+
+        gbc.insets = new Insets(2, 2, 2, 2);
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+
+        this.createEnableCheckBox();
+        this.createScenesPanel();
+        this.createCopyPathButton();
+
+        this.updateScenesPanel();
+
+        this.add(this.mainPanel);
+
+        gc.setRow(0);
+        this.mainPanel.add(this.enablePanel, gc);
+        gc.setRow(1);
+        this.mainPanel.add(this.scenesPanel, gc);
+        gc.setRow(2);
+        this.mainPanel.add(this.copyPathPanel, gc);
+
         this.setVisible(true);
     }
 
-    private void setUpWindow() {
-        this.setLayout(new GridBagLayout());
-        enabledCheckBox = new JCheckBox();
-        playingField = new JTextField(15);
-        magField = new JTextField(15);
-        plannarAbuseField = new JTextField(15);
-        thinField = new JTextField(15);
-        keyButton = new JButton("Hotkey");
-        scenesPanel = new JPanel(new GridBagLayout());
-        scenesPanel.setBorder(BorderFactory.createTitledBorder("Scene Names"));
-        JPanel customScenesPanel = new JPanel(new GridBagLayout());
-        addSceneButton = new JButton("Add Custom Scene");
-
-        GridBagConstraints gbc = createGbc();
-        int y = 0;
-        addLabelAndComponent("Enabled", enabledCheckBox, gbc, y++);
-        addLabelAndComponent("Playing Scene", playingField, gbc, y++);
-        addPanel(scenesPanel, gbc, y++);
-        addPanel(customScenesPanel, gbc, y++);
-        addSceneFields(scenesPanel, customScenesPanel);
-        addSceneButtonListener(customScenesPanel);
-
-        JButton copyPathButton = new JButton("Copy script path to clipboard");
-        copyPathButton.addActionListener(e -> {
-            String path = SceneSwitcher.getLuaScriptPath().toAbsolutePath().toString();
-            StringSelection selection = new StringSelection(path);
-            Toolkit.getDefaultToolkit().getSystemClipboard().setContents(selection, selection);
-            Jingle.log(Level.INFO, "(SceneSwitcher) Copied lua script path to clipboard");
-        });
-
-        // Add button near the bottom
-        gbc.gridy = 100; // High value to ensure it's at the bottom
-        gbc.gridx = 0;
-        gbc.gridwidth = 4;
-        this.add(copyPathButton, gbc);
-    }
-
-    private void initializeFields(SceneSwitcherOptions options) {
-        enabledCheckBox.setSelected(options.enabled);
-        playingField.setText(options.playing_scene.name);
-        magField.setText(options.mag_scene.name);
-        plannarAbuseField.setText(options.plannar_abuse_scene.name);
-        thinField.setText(options.thin_scene.name);
-        
-        SceneSwitcher.updatePlayingScene(options.playing_scene.name);
-    }
-
-    private void addListeners(SceneSwitcherOptions options) {
-        enabledCheckBox.addActionListener(e -> toggleFields(checkBoxEnabled()));
-        KeyAdapter saveKeyListener = new KeyAdapter() {
-            @Override
-            public void keyReleased(KeyEvent e) {
-                save();
-                if (e.getSource() == playingField) {
-                    SceneSwitcher.updatePlayingScene(playingField.getText());
-                }
-            }
-        };
-        playingField.addKeyListener(saveKeyListener);
-        magField.addKeyListener(saveKeyListener);
-        plannarAbuseField.addKeyListener(saveKeyListener);
-        thinField.addKeyListener(saveKeyListener);
-        keyButton.addActionListener(a -> setHotkey());
-    }
-
-    private void setInitialStates(SceneSwitcherOptions options) {
-        enabledCheckBox.setSelected(options.enabled);
-        toggleFields(checkBoxEnabled());
-    }
-
-    private void toggleFields(boolean enabled) {
-        playingField.setEnabled(enabled);
-        magField.setEnabled(enabled);
-        plannarAbuseField.setEnabled(enabled);
-        thinField.setEnabled(enabled);
-        keyButton.setEnabled(enabled);
-        addSceneButton.setEnabled(enabled);
-        customSceneFields.values().forEach(field -> field.setEnabled(enabled));
-        save();
-    }
-
-    private void setHotkey() {
-        synchronized (this) {
-            keyButton.setText("...");
-            keyButton.setEnabled(false);
-            Hotkey.onNextHotkey(() -> true, hotkey -> {
-                keyButton.setText(hotkey.toString());
-                keyButton.setEnabled(checkBoxEnabled());
-                PluginHotkeys.addHotkeyAction("hotkey trigger created", () -> SceneSwitcher.switchToPlannarAbuse(plannarAbuseField.getText()));
-            });
-        }
-    }
-
-    private void addSceneFields(JPanel scenesPanel, JPanel customScenesPanel) {
-        GridBagConstraints sgbc = createGbc();
-        int sy = 0;
-        addLabelAndComponent("Mag Scene:", magField, sgbc, sy++, scenesPanel);
-        addLabelAndComponent("Wide Scene:", plannarAbuseField, sgbc, sy++, scenesPanel);
-        addLabelAndComponent("Thin Scene:", thinField, sgbc, sy++, scenesPanel);
-        addSeparator(sgbc, sy++, scenesPanel);
-        addPanel(customScenesPanel, sgbc, sy++, scenesPanel);
+    private void createEnableCheckBox() {
         SceneSwitcherOptions options = SceneSwitcherOptions.getInstance();
-        CustomSceneCounter customCounter = new CustomSceneCounter(0);
-        options.custom_scenes.forEach((key, value) -> addCustomSceneField(key, value.name, customCounter.value++, customScenesPanel));
-        addPanel(addSceneButton, sgbc, sy++, scenesPanel);
-    }
 
-    private void addSceneButtonListener(JPanel customScenesPanel) {
-        addSceneButton.addActionListener(e -> {
-            String sceneName = JOptionPane.showInputDialog(this, "Enter Custom Scene Label:");
-            if (sceneName != null && !sceneName.trim().isEmpty()) {
-                customScenesPanel.remove(addSceneButton);
-                addCustomSceneField(sceneName, "", customCounter.value++, customScenesPanel);
-                addPanel(addSceneButton, createGbc(), customCounter.value, customScenesPanel);
-                save();
-                customScenesPanel.revalidate();
-                customScenesPanel.repaint();
-            }
-        });
-    }
+        JLabel enabledLabel = new JLabel("Enable Scene Switcher?");
+        JCheckBox enabledCheckBox = new JCheckBox();
 
-    private void addCustomSceneField(String sceneId, String sceneName, int y, JPanel panel) {
-        JLabel sceneIdLabel = new JLabel(sceneId + ":");
-        JTextField sceneNameField = new JTextField(sceneName, 15);
-        sceneNameField.addKeyListener(new KeyAdapter() {
-            @Override
-            public void keyReleased(KeyEvent e) {
-                save();
-            }
-        });
-        JButton removeButton = createRemoveButton(sceneId, panel, sceneIdLabel, sceneNameField);
-        PluginHotkeys.addHotkeyAction("Scene Switcher - " + sceneId, () -> SceneSwitcher.switchToCustom(sceneNameField.getText()));
-        Jingle.log(Level.INFO, "(SceneSwitcher) Added hotkey action for scene ID \"" + sceneId + "\"");
-        customSceneFields.put(sceneId, sceneNameField);
-        addComponentsToPanel(panel, sceneIdLabel, sceneNameField, removeButton, y);
-        sceneNameField.setEnabled(checkBoxEnabled());
-    }
-
-    private JButton createRemoveButton(String sceneId, JPanel panel, JLabel sceneIdLabel, JTextField sceneNameField) {
-        JButton removeButton = new JButton("×");
-        removeButton.setMargin(new Insets(0, 4, 0, 4));
-        removeButton.addActionListener(e -> {
-            removeCustomScene(sceneId);
-            panel.remove(sceneIdLabel);
-            panel.remove(sceneNameField);
-            panel.remove(removeButton);
-            save();
-            panel.revalidate();
-            panel.repaint();
-        });
-        return removeButton;
-    }
-
-    private void addComponentsToPanel(JPanel panel, JLabel sceneIdLabel, JTextField sceneNameField, JButton removeButton, int y) {
-        GridBagConstraints gbc = createGbc();
-        addComponent(panel, sceneIdLabel, gbc, 0, y, 1);
-        addComponent(panel, sceneNameField, gbc, 1, y, 2);
-        addComponent(panel, removeButton, gbc, 3, y, 1);
-    }
-
-    private void removeCustomScene(String sceneId) {
-        HotkeyUtil.removeHotkeyAction("Scene Switcher - " + sceneId);
-        Jingle.log(Level.INFO, "(SceneSwitcher) Removed hotkey action for scene ID\"" + sceneId + "\"");
-        customSceneFields.remove(sceneId);
-        save();
-    }
-
-    public static SceneSwitcherGUI open(Point initialLocation) {
-        if (instance == null || instance.isClosed()) {
-            instance = new SceneSwitcherGUI();
-            if (initialLocation != null) {
-                instance.setLocation(initialLocation);
-            }
-        } else {
-            instance.requestFocus();
-        }
-        return instance;
-    }
-
-    private void save() {
-        SceneSwitcherOptions options = SceneSwitcherOptions.getInstance();
-        options.enabled = checkBoxEnabled();
-        options.playing_scene = new SceneSwitcherOptions.SceneData(playingField.getText());
-        options.mag_scene.name = magField.getText();
-        options.plannar_abuse_scene.name = plannarAbuseField.getText();
-        options.thin_scene.name = thinField.getText();
-        options.custom_scenes.clear();
-        customSceneFields.forEach((key, value) -> options.custom_scenes.put(key, new SceneSwitcherOptions.SceneData(value.getText())));
-        try {
+        enabledCheckBox.setSelected(options.enabled);
+        enabledCheckBox.addActionListener(e -> {
+            options.enabled = enabledCheckBox.isSelected();
             SceneSwitcherOptions.save();
-        } catch (IOException ex) {
-            throw new RuntimeException(ex);
+            this.updateScenesPanel();
+            Jingle.log(Level.INFO, options.enabled ? "(SceneSwitcher) Scene Switcher is now active." : "(SceneSwitcher) Scene Switcher is no longer active.");
+        });
+
+        this.enablePanel.add(enabledLabel, gbc);
+        this.enablePanel.add(enabledCheckBox, gbc);
+    }
+
+    private void createScenesPanel() {
+        this.scenesPanel.setBorder(BorderFactory.createTitledBorder("OBS States"));
+    }
+
+    private void createCopyPathButton() {
+        JButton copyPathButton = new JButton("Copy script path to clipboard");
+
+        copyPathButton.addActionListener(e -> {
+            try {
+                KeyboardUtil.copyToClipboard(SceneSwitcher.getLuaScriptPath().toAbsolutePath().toString());
+                Jingle.log(Level.INFO, "(SceneSwitcher) Copied lua script path to clipboard");
+            } catch (Exception ex) {
+                JOptionPane.showMessageDialog(this.mainPanel, "(SceneSwitcher) Failed to copy to clipboard: " + ExceptionUtil.toDetailedString(ex));
+            }
+        });
+
+        this.copyPathPanel.add(copyPathButton, gbc);
+    }
+
+    public void updateScenesPanel() {
+        SceneSwitcherOptions options = SceneSwitcherOptions.getInstance();
+
+        this.scenesPanel.removeAll();
+        gbc.gridy = 0;
+
+        addObsStateElement(new ObsStateElement.Labels(this));
+
+        for (ObsState obsState: options.obsStates) {
+            if (obsState.equals(SceneSwitcherOptions.getDefaultState())) {
+                addObsStateElement(new ObsStateElement.DefaultState(this, obsState));
+            } else {
+                addObsStateElement(new ObsStateElement(this, obsState));
+            }
         }
+
+        this.addAddSceneButton();
+
+        this.mainPanel.revalidate();
+        this.mainPanel.repaint();
     }
 
-    private boolean checkBoxEnabled() {
-        return enabledCheckBox.isSelected();
+    private void addObsStateElement(ObsStateElement obsStateElement) {
+        obsStateElement.build();
+        obsStateElement.setEnabled(SceneSwitcherOptions.getInstance().enabled);
     }
 
-    public boolean isClosed() {
-        return closed;
+    private void addAddSceneButton() {
+        SceneSwitcherOptions options = SceneSwitcherOptions.getInstance();
+        JButton addSceneButton = new JButton("Add State");
+
+        addSceneButton.addActionListener(e -> {
+            Function<String, Object> askNameFunc = s -> JOptionPane.showInputDialog(
+                    this.mainPanel,
+                    s + "Enter new OBS State Label:",
+                    "Scene Switcher: New OBS State",
+                    JOptionPane.QUESTION_MESSAGE,
+                    null,
+                    null,
+                    ""
+            );
+
+            Object nameAnsObj = askNameFunc.apply("");
+            if (nameAnsObj == null) return;
+            while (SceneSwitcherOptions.matchingExistingName(nameAnsObj.toString()) && nameAnsObj.toString().trim().isEmpty()) {
+                nameAnsObj = askNameFunc.apply("Invalid input!\n");
+            }
+
+            Object initialSelection = CustomizableManager.get("Resizing", nameAnsObj.toString());
+
+            Function<String, Object> askDimensionsFunc = s -> JOptionPane.showInputDialog(
+                    this.mainPanel,
+                    s + "Enter the width and height resize dimensions for new OBS State separated by an 'x' (eg. \"250x1080\"):",
+                    "Scene Switcher: New OBS State",
+                    JOptionPane.QUESTION_MESSAGE,
+                    null,
+                    null,
+                    initialSelection == null ? "250x1080" : initialSelection.toString()
+            );
+
+            Object dimensionsAnsObj = askDimensionsFunc.apply("");
+            if (dimensionsAnsObj == null) return;
+            while (!ObsState.isValidDimensionsString(dimensionsAnsObj.toString())) {
+                dimensionsAnsObj = askDimensionsFunc.apply(dimensionsAnsObj.toString().trim().isEmpty() ? "Invalid input!\n" : "Those resize dimensions are already being used!\n");
+            }
+
+            options.obsStates.add(new ObsState(nameAnsObj.toString(), dimensionsAnsObj.toString(), "Playing", ""));
+            SceneSwitcherOptions.save();
+            this.updateScenesPanel();
+        });
+        this.scenesPanel.add(addSceneButton, gbc);
+        addSceneButton.setEnabled(options.enabled);
     }
 
-    private GridBagConstraints createGbc() {
-        GridBagConstraints gbc = new GridBagConstraints();
-        gbc.insets = new Insets(5, 5, 5, 5);
-        gbc.fill = GridBagConstraints.HORIZONTAL;
-        gbc.anchor = GridBagConstraints.WEST;
-        return gbc;
-    }
-
-    private void addLabelAndComponent(String labelText, JComponent component, GridBagConstraints gbc, int y) {
-        addComponent(this, new JLabel(labelText), gbc, 0, y, 1);
-        addComponent(this, component, gbc, 1, y, 3);
-    }
-
-    private void addLabelAndComponent(String labelText, JComponent component, GridBagConstraints gbc, int y, JPanel panel) {
-        addComponent(panel, new JLabel(labelText), gbc, 0, y, 1);
-        addComponent(panel, component, gbc, 1, y, 3);
-    }
-
-    private void addComponent(JPanel panel, JComponent component, GridBagConstraints gbc, int x, int y, int width) {
-        gbc.gridx = x;
-        gbc.gridy = y;
-        gbc.gridwidth = width;
-        panel.add(component, gbc);
-    }
-
-    private void addPanel(JPanel panel, GridBagConstraints gbc, int y) {
-        gbc.gridx = 0;
-        gbc.gridy = y;
-        gbc.gridwidth = 4;
-        this.add(panel, gbc);
-    }
-
-    private void addPanel(JComponent component, GridBagConstraints gbc, int y, JPanel panel) {
-        gbc.gridx = 0;
-        gbc.gridy = y;
-        gbc.gridwidth = 4;
-        panel.add(component, gbc);
-    }
-
-    private void addSeparator(GridBagConstraints gbc, int y, JPanel panel) {
-        addComponent(panel, new JSeparator(), gbc, 0, y, 4);
-    }
-
-    private class CustomSceneCounter {
-        int value;
-        CustomSceneCounter(int initial) { value = initial; }
+    public JPanel getScenesPanel() {
+        return this.scenesPanel;
     }
 }

--- a/src/main/java/me/disheiX/switcher/state/ObsState.java
+++ b/src/main/java/me/disheiX/switcher/state/ObsState.java
@@ -59,8 +59,16 @@ public class ObsState {
     public String getFullString(ObsState oldState) {
         List<String> oldSources = oldState.name.equals("Playing") ? SceneSwitcherOptions.getAllSources() : oldState.toggledSources;
         List<String> newSources = this.name.equals("Playing") ? SceneSwitcherOptions.getAllSources() : this.toggledSources;
-        String toggleOn = newSources.stream().filter(newSource -> !oldSources.contains(newSource)).collect(Collectors.joining("&"));
-        String toggleOff = oldSources.stream().filter(oldSource -> !newSources.contains(oldSource)).collect(Collectors.joining("&"));
+
+        String toggleOn = newSources.stream()
+                .filter(newSource -> !oldSources.contains(newSource))
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.joining("&"));
+        String toggleOff = oldSources.stream()
+                .filter(oldSource -> !newSources.contains(oldSource))
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.joining("&"));
+
         return String.join("|", "name=" + this.getName(), "scene=" + this.getActiveScene(), "on=" + toggleOn, "off=" + toggleOff);
     }
 

--- a/src/main/java/me/disheiX/switcher/state/ObsState.java
+++ b/src/main/java/me/disheiX/switcher/state/ObsState.java
@@ -1,0 +1,78 @@
+package me.disheiX.switcher.state;
+
+import me.disheiX.switcher.SceneSwitcherOptions;
+
+import java.awt.*;
+import java.util.*;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class ObsState {
+    private String name;
+    private int width;
+    private int height;
+    private String activeScene;
+    private List<String> toggledSources;
+
+    public ObsState(String name, String sizeString, String activeScene, String toggledSources) {
+        this.setName(name);
+        this.setDimensions(sizeString);
+        this.setActiveScene(activeScene);
+        this.setToggledSources(toggledSources);
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setActiveScene(String scene) {
+        this.activeScene = scene;
+    }
+
+    public void setToggledSources(String toggledSources) {
+        this.toggledSources = Arrays.stream(toggledSources.split(",")).map(String::trim).collect(Collectors.toList());
+    }
+
+    public void setDimensions(String string) {
+        String[] dimensions = string.split("x");
+        this.width = Integer.parseInt(dimensions[0]);
+        this.height = Integer.parseInt(dimensions[1]);
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getActiveScene() {
+        return this.activeScene;
+    }
+
+    public List<String> getToggledSources() {
+        return this.toggledSources;
+    }
+
+    public String getDimensions() {
+        return this.width + "x" + this.height;
+    }
+
+    public String getFullString(ObsState oldState) {
+        List<String> oldSources = oldState.name.equals("Playing") ? SceneSwitcherOptions.getAllSources() : oldState.toggledSources;
+        List<String> newSources = this.name.equals("Playing") ? SceneSwitcherOptions.getAllSources() : this.toggledSources;
+        String toggleOn = newSources.stream().filter(newSource -> !oldSources.contains(newSource)).collect(Collectors.joining("&"));
+        String toggleOff = oldSources.stream().filter(oldSource -> !newSources.contains(oldSource)).collect(Collectors.joining("&"));
+        return String.join("|", "name=" + this.getName(), "scene=" + this.getActiveScene(), "on=" + toggleOn, "off=" + toggleOff);
+    }
+
+    public boolean matchesRectangle(Rectangle rectangle) {
+        return this.width == rectangle.width && this.height == rectangle.height;
+    }
+
+    public static boolean isValidDimensionsString(String input) {
+        return Pattern.matches("^\\d+x\\d+$", input) && !SceneSwitcherOptions.matchingExistingDimensions(input);
+    }
+
+    public static boolean isValidSourcesListString(String input) {
+        return Pattern.matches("^([\\w ]+:[\\w ]+($|[, ]+))*$", input);
+    }
+}

--- a/src/main/java/me/disheiX/switcher/state/ObsStateManager.java
+++ b/src/main/java/me/disheiX/switcher/state/ObsStateManager.java
@@ -1,0 +1,24 @@
+package me.disheiX.switcher.state;
+
+import org.apache.logging.log4j.Level;
+import xyz.duncanruns.jingle.Jingle;
+import xyz.duncanruns.jingle.util.FileUtil;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class ObsStateManager {
+    private static final Path OUT = Jingle.FOLDER.resolve("obs-switcher-state");
+
+    public static ObsState updateState(ObsState lastState, ObsState newState) {
+        String output = newState.getFullString(lastState);
+        try {
+            FileUtil.writeString(OUT, output);
+            Jingle.log(Level.DEBUG, "(SceneSwitcher) Writing new state: " + output + "\n" +
+                    "to file: " + OUT);
+        } catch (IOException e) {
+            Jingle.logError("(SceneSwitcher) Failed to write obs-switcher-state:", e);
+        }
+        return newState;
+    }
+}

--- a/src/main/java/me/disheiX/switcher/util/ResizingStateUtil.java
+++ b/src/main/java/me/disheiX/switcher/util/ResizingStateUtil.java
@@ -4,7 +4,7 @@ import xyz.duncanruns.jingle.resizing.Resizing;
 import java.lang.reflect.Field;
 
 public class ResizingStateUtil {
-    private static Field currentlyResizedField;
+    private static final Field currentlyResizedField;
 
     static {
         try {

--- a/src/main/resources/jingle-obs-switcher.lua
+++ b/src/main/resources/jingle-obs-switcher.lua
@@ -34,6 +34,16 @@ function split_string(input_string, split_char)
 end
 
 ---- Obs Functions ----
+function get_scene(name)
+    local source = get_source(name)
+    if source == nil then
+        return nil
+    end
+    local scene = obs.obs_scene_from_source(source)
+    release_source(source)
+    return scene
+end
+
 function get_source(name)
     return obs.obs_get_source_by_name(name)
 end
@@ -52,6 +62,19 @@ function switch_to_scene(scene_name)
     return true
 end
 
+function set_item_visible(scene_name, item_name, visible)
+    local scene = get_scene(scene_name)
+    if (scene == nil) then
+        return
+    end
+    local item = obs.obs_scene_find_source_recursive(scene, item_name)
+    if (item == nil) then
+        return
+    end
+    print("setting " .. scene_name .. ":" .. item_name .. " visibility: " .. tostring(visible))
+    obs.obs_sceneitem_set_visible(item, visible)
+end
+
 ---- Script Functions ----
 function script_description()
     return [[
@@ -64,37 +87,40 @@ function script_load()
     last_scene_state = get_state_file_string("obs-switcher-state")
 end
 
-function script_update(settings)
+function script_update(_)
     if not timers_activated then
         timers_activated = true
         obs.timer_add(loop, 20)
     end
 end
 
-function loop()
-    local link_state = get_state_file_string("obs-link-state")
-    local scene_state = get_state_file_string("obs-switcher-state")
-    if (scene_state == last_scene_state or scene_state == nil) then
-        return
-    end
-    
-    local state_link_args = split_string(link_state, '|')
-    if state_link_args[1] == 'W' then
-        return
-    end
-
-    last_scene_state = scene_state
-    local state_scene_args = split_string(scene_state, '|')
-    if (#state_scene_args < 5) then return end
-    if table.concat(state_scene_args, '', 2, 5) == 'NNNN' then
-        switch_to_scene(state_scene_args[1])
-    else
-        for i = 2, 5 do
-            if state_scene_args[i] ~= 'N' then
-                switch_to_scene(state_scene_args[i])
-                break
-            end
+function toggle_sources(sources, toggle)
+    sources = split_string(sources, "=")
+    if (sources[2] ~= nil) then
+        sources[2] = split_string(sources[2], "&")
+        for _, source in ipairs(sources[2]) do
+            local source_data = split_string(source, ':')
+            set_item_visible(source_data[1], source_data[2], toggle)
         end
     end
 end
 
+function loop()
+    local link_state = get_state_file_string("obs-link-state")
+    local scene_state = get_state_file_string("obs-switcher-state")
+    if (scene_state == nil or scene_state == last_scene_state or split_string(link_state, '|')[1] == 'W') then
+        return
+    end
+
+    local last_state_args = split_string(last_scene_state, '|')
+    local new_state_args = split_string(scene_state, '|')
+
+    toggle_sources(new_state_args[3], true)
+    toggle_sources(new_state_args[4], false)
+
+    if (last_state_args[2] ~= new_state_args[2]) then
+        switch_to_scene(split_string(new_state_args[2], "=")[2])
+    end
+
+    last_scene_state = scene_state
+end


### PR DESCRIPTION
- the gui is more modular and directly changes the settings instead of asking the parent gui to save the settings
- automatically switching to associated obs states based on the matching resize dimensions
- list obs sources and their parent scenes to have them be toggled on and off with obs state switching
- no more hotkey double binding stuff since its all automatic now
- lots of info stuff written in to built in buttons so users can know exactly what things does
- default settings based on the default resize jingle script storage for convenience of users
- defaults to "Playing" scene as thats the default for jingle in general

idk idk im just thought this was so cool so then i wanted to make it more automatic and a bit more features i think its pretty aight idk